### PR TITLE
fix leak issue.

### DIFF
--- a/WGradientProgress/WGradientProgress.m
+++ b/WGradientProgress/WGradientProgress.m
@@ -79,6 +79,7 @@
     if ([self superview]) {
         [self removeFromSuperview];
     }
+    self.parentView = nil;
 }
 
 #pragma mark -- setter / getter


### PR DESCRIPTION
release parentView when hide function called.A singleton object should not keep a strong reference to its super view.
